### PR TITLE
Move search path to all configs

### DIFF
--- a/launcher_scripts/conf/config.yaml
+++ b/launcher_scripts/conf/config.yaml
@@ -22,6 +22,9 @@ hydra:
   run:
     dir: .
   output_subdir: null
+  searchpath:
+    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+
 
 debug: False
 

--- a/launcher_scripts/conf/training/gpt3/126m.yaml
+++ b/launcher_scripts/conf/training/gpt3/126m.yaml
@@ -1,7 +1,3 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
-
 run:
   name: gpt3_126m
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/gpt3/175b.yaml
+++ b/launcher_scripts/conf/training/gpt3/175b.yaml
@@ -1,7 +1,3 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
-
 run:
   name: gpt3_175b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/gpt3/175b_fp8.yaml
+++ b/launcher_scripts/conf/training/gpt3/175b_fp8.yaml
@@ -1,10 +1,6 @@
 # The configurations below provide the best 175B training performance with the NeMo SW stack.
 # We have confirmed the model convergence only with a limited number of tokens and the full model
 # convergence (e.g., 300B tokens) is not guaranteed.
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
-
 run:
   name: gpt3_175b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/gpt3/1b_improved.yaml
+++ b/launcher_scripts/conf/training/gpt3/1b_improved.yaml
@@ -1,7 +1,3 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
-
 run:
   name: gpt_1b_improved
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/gpt3/20b.yaml
+++ b/launcher_scripts/conf/training/gpt3/20b.yaml
@@ -1,7 +1,3 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
-
 run:
   name: gpt3_20b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/gpt3/400m_improved.yaml
+++ b/launcher_scripts/conf/training/gpt3/400m_improved.yaml
@@ -1,7 +1,3 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
-
 run:
   name: gpt_400m_improved
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/gpt3/40b.yaml
+++ b/launcher_scripts/conf/training/gpt3/40b.yaml
@@ -1,7 +1,3 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
-
 run:
   name: gpt3_40b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/gpt3/40b_improved.yaml
+++ b/launcher_scripts/conf/training/gpt3/40b_improved.yaml
@@ -1,7 +1,3 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
-
 run:
   name: gpt_40b_improved
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/gpt3/5b.yaml
+++ b/launcher_scripts/conf/training/gpt3/5b.yaml
@@ -1,7 +1,3 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
-
 run:
   name: gpt3_5b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/gpt3/7b_improved.yaml
+++ b/launcher_scripts/conf/training/gpt3/7b_improved.yaml
@@ -1,7 +1,3 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
-
 run:
   name: gpt_7b_improved
   results_dir: ${base_results_dir}/${.name}


### PR DESCRIPTION
All the configs in launcher_scripts/conf directory refer to language models, so I moved the additional search path from individual config level to the top level config.
This makes configs in NeMo discoverable by hydra from the launcher. Now tp configs should be discoverable for all LM models.
To add new tp config:
1. Place the tp config under `NeMo/examples/nlp/language_modeling/conf/tp_overlap`
2. Launch script with `+tp_overlap@model.ub_tp_comm_overlap_cfg=<config_name>` (name without `.yaml`). This step should be handled automatically by the launcher.

I think that keeping configs in 2 separate directories, repositories even, is confusing and leads to many mistakes. It would be easier if all configuration files not related directly to launcher utility were moved to NeMo. In this repo they should only be imported from there.

@erhoo82 please test this MR