### PR TITLE
set transformer_engine=true in gpt3/mcore base config

### DIFF
--- a/auto_configurator/base_configs/gpt3.yaml
+++ b/auto_configurator/base_configs/gpt3.yaml
@@ -113,7 +113,7 @@ model:
   mcore_gpt: True
 
   ## Transformer Engine
-  transformer_engine: False
+  transformer_engine: True # enables the use of Transformer Engine modules
   fp8: False # enables fp8 in TransformerLayer forward
   fp8_e4m3: False # sets fp8_format = recipe.Format.E4M3
   fp8_hybrid: True # sets fp8_format = recipe.Format.HYBRID


### PR DESCRIPTION
At `mcore_gpt=true`, `transformer_engine=true` should be the default value for performance regardless.

`transformer_engine=true` uses Transformer Engine modules in a Mcore/TransformerLayer, and this is the requirement for using fp8 training.

