### PR TITLE
enable SP in mixtral-8x7b

### DIFF
--- a/launcher_scripts/conf/conversion/mistral/convert_mistral.yaml
+++ b/launcher_scripts/conf/conversion/mistral/convert_mistral.yaml
@@ -17,5 +17,6 @@ model:
   checkpoint_name: latest # latest OR name pattern of a checkpoint (e.g. megatron_llama-*last.ckpt)
   hparams_file: ${conversion.run.train_dir}/results/hparams.yaml
   tensor_model_parallel_size: 2
+  sequence_parallel: True
   pipeline_model_parallel_size: 1
   model_parallel_size: ${multiply:${.tensor_model_parallel_size}, ${.pipeline_model_parallel_size}}

--- a/launcher_scripts/conf/evaluation/mixtral/evaluate_all.yaml
+++ b/launcher_scripts/conf/evaluation/mixtral/evaluate_all.yaml
@@ -18,6 +18,7 @@ model:
   #hparams_file: ${evaluation.run.train_dir}/results/hparams.yaml
   tensor_model_parallel_size: 8
   pipeline_model_parallel_size: 1
+  sequence_parallel: True
   model_parallel_size: ${multiply:${.tensor_model_parallel_size}, ${.pipeline_model_parallel_size}}
   precision: bf16 # must match training precision - 32, 16 or bf16
   eval_batch_size: 4

--- a/launcher_scripts/conf/evaluation/mixtral/evaluate_all_8x22b.yaml
+++ b/launcher_scripts/conf/evaluation/mixtral/evaluate_all_8x22b.yaml
@@ -18,6 +18,7 @@ model:
   #hparams_file: ${evaluation.run.train_dir}/results/hparams.yaml
   tensor_model_parallel_size: 8
   pipeline_model_parallel_size: 1
+  sequence_parallel: True
   model_parallel_size: ${multiply:${.tensor_model_parallel_size}, ${.pipeline_model_parallel_size}}
   precision: bf16 # must match training precision - 32, 16 or bf16
   eval_batch_size: 4

--- a/launcher_scripts/conf/evaluation/peft_mixtral/squad.yaml
+++ b/launcher_scripts/conf/evaluation/peft_mixtral/squad.yaml
@@ -39,7 +39,7 @@ model:
   sync_batch_comm: False
   megatron_amp_02: False
 
-  sequence_parallel: False
+  sequence_parallel: True
 
   activations_checkpoint_granularity: null
   activations_checkpoint_method: null

--- a/launcher_scripts/conf/evaluation/peft_mixtral/squad_8x22b.yaml
+++ b/launcher_scripts/conf/evaluation/peft_mixtral/squad_8x22b.yaml
@@ -39,7 +39,7 @@ model:
   sync_batch_comm: False
   megatron_amp_02: False
 
-  sequence_parallel: False
+  sequence_parallel: True
 
   activations_checkpoint_granularity: null
   activations_checkpoint_method: null

--- a/launcher_scripts/conf/fine_tuning/mistral/squad.yaml
+++ b/launcher_scripts/conf/fine_tuning/mistral/squad.yaml
@@ -57,7 +57,7 @@ model:
   ## Sequence Parallelism
   # Makes tensor parallelism more memory efficient for LLMs (20B+) by parallelizing layer norms and dropout sequentially
   # See Reducing Activation Recomputation in Large Transformer Models: https://arxiv.org/abs/2205.05198 for more details.
-  sequence_parallel: False
+  sequence_parallel: True
 
   ## Activation Checkpoint
   activations_checkpoint_granularity: selective # 'selective' or 'full'

--- a/launcher_scripts/conf/fine_tuning/mixtral/squad.yaml
+++ b/launcher_scripts/conf/fine_tuning/mixtral/squad.yaml
@@ -57,7 +57,7 @@ model:
   ## Sequence Parallelism
   # Makes tensor parallelism more memory efficient for LLMs (20B+) by parallelizing layer norms and dropout sequentially
   # See Reducing Activation Recomputation in Large Transformer Models: https://arxiv.org/abs/2205.05198 for more details.
-  sequence_parallel: False
+  sequence_parallel: True
 
   ## Activation Checkpoint
   activations_checkpoint_granularity: selective # 'selective' or 'full'

--- a/launcher_scripts/conf/fine_tuning/mixtral/squad_8x22b.yaml
+++ b/launcher_scripts/conf/fine_tuning/mixtral/squad_8x22b.yaml
@@ -57,7 +57,7 @@ model:
   ## Sequence Parallelism
   # Makes tensor parallelism more memory efficient for LLMs (20B+) by parallelizing layer norms and dropout sequentially
   # See Reducing Activation Recomputation in Large Transformer Models: https://arxiv.org/abs/2205.05198 for more details.
-  sequence_parallel: False
+  sequence_parallel: True
 
   ## Activation Checkpoint
   activations_checkpoint_granularity: selective # 'selective' or 'full'

--- a/launcher_scripts/conf/peft/mixtral/squad.yaml
+++ b/launcher_scripts/conf/peft/mixtral/squad.yaml
@@ -70,7 +70,7 @@ model:
   ## Sequence Parallelism
   # Makes tensor parallelism more memory efficient for LLMs (20B+) by parallelizing layer norms and dropout sequentially
   # See Reducing Activation Recomputation in Large Transformer Models: https://arxiv.org/abs/2205.05198 for more details.
-  sequence_parallel: False
+  sequence_parallel: True
 
   ## Activation Checkpoint
   activations_checkpoint_granularity: null # 'selective' or 'full'

--- a/launcher_scripts/conf/training/mixtral/mixtral_8x7b.yaml
+++ b/launcher_scripts/conf/training/mixtral/mixtral_8x7b.yaml
@@ -125,7 +125,7 @@ model:
   activations_checkpoint_num_layers: null
   num_micro_batches_with_partial_activation_checkpoints: null
   activations_checkpoint_layers_per_pipeline: null
-  sequence_parallel: false
+  sequence_parallel: true
   transformer_engine: true
   fp8: false
   fp8_e4m3: false


### PR DESCRIPTION
Avoid triggering `raise ValueError(
ValueError: When using expert parallelism and tensor parallelism, sequence parallelism must be used`, since both EP & TP are enabled. 