### PR TITLE
Support Python 3.9 typehinting syntax

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,5 +43,4 @@ repos:
     hooks:
       - id: black
         name: Format code
-        args: [--skip-string-normalization, --line-length=119]
         additional_dependencies: ['click==8.0.2']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
     hooks:
       - id: isort
         name: Format imports
+        args: ['--profile', 'black', '--line-length', '88']
         exclude: docs/
 
   - repo: https://github.com/psf/black

--- a/launcher_scripts/nemo_launcher/core/v2/config_k8s.py
+++ b/launcher_scripts/nemo_launcher/core/v2/config_k8s.py
@@ -1,22 +1,24 @@
-from enum import Enum
-from typing import Optional, Union, overload
-
-from hera.workflows.models import (  # TODO: Use these BaseModels when solution we have solution to: https://github.com/argoproj-labs/hera/issues/984; NFSVolumeSource,; HostPathVolumeSource,; PersistentVolumeClaimVolumeSource,
+from pydantic import BaseModel, validator, Field, computed_field, model_validator
+from kubernetes.client import (
+    V1VolumeMount,
+    V1Volume,
+    V1NFSVolumeSource,
+    V1HostPathVolumeSource,
+    V1PersistentVolumeClaimVolumeSource,
+    V1EmptyDirVolumeSource,
+)
+from hera.workflows.models import (
     Volume,
     VolumeMount,
-)
-from hydra.utils import get_class
-from kubernetes.client import (
-    V1EmptyDirVolumeSource,
-    V1HostPathVolumeSource,
-    V1NFSVolumeSource,
-    V1PersistentVolumeClaimVolumeSource,
-    V1Volume,
-    V1VolumeMount,
+    # TODO: Use these BaseModels when solution we have solution to: https://github.com/argoproj-labs/hera/issues/984
+    # NFSVolumeSource,
+    # HostPathVolumeSource,
+    # PersistentVolumeClaimVolumeSource,
 )
 from omegaconf import OmegaConf
-from pydantic import BaseModel, Field, computed_field, model_validator, validator
-
+from hydra.utils import get_class
+from typing import overload, Optional, Union
+from enum import Enum
 
 # TODO: Use these BaseModels until a solution to this exists: https://github.com/argoproj-labs/hera/issues/984
 class NFSVolumeSource(BaseModel):

--- a/launcher_scripts/nemo_launcher/core/v2/stages.py
+++ b/launcher_scripts/nemo_launcher/core/v2/stages.py
@@ -1,26 +1,35 @@
-import os
-from pathlib import Path
-from textwrap import dedent
-from typing import Any, ClassVar, Optional
-
-from hera.workflows import DAG, Container, Parameter, Step, Steps, Workflow
-from hera.workflows import models as m
-from hera.workflows import script
-from nemo_launcher.core.launchers import K8SLauncherV2
-from nemo_launcher.core.stages import create_args_list
-from nemo_launcher.core.v2.config_k8s import (
-    K8sClusterConfig,
-    adapt_volume_to,
-    instantiate_model_from_omegaconf,
-)
+from pydantic import BaseModel
 from nemo_launcher.core.v2.step_k8s import (
-    create_mpijob_resource,
     create_pytorchjob_resource,
+    create_mpijob_resource,
     delete_pytorchjob,
 )
+from nemo_launcher.core.v2.config_k8s import (
+    K8sClusterConfig,
+    instantiate_model_from_omegaconf,
+    adapt_volume_to,
+)
+from omegaconf import DictConfig
+from typing import Any, ClassVar, Optional
+from hera.workflows import (
+    Container,
+    Parameter,
+    Step,
+    Steps,
+    Workflow,
+    script,
+    Parameter,
+    DAG,
+    models as m,
+)
+import os
+from omegaconf import OmegaConf
 from nemo_launcher.utils.job_utils import JobPaths
-from omegaconf import DictConfig, OmegaConf
-from pydantic import BaseModel, computed_field
+from nemo_launcher.core.launchers import K8SLauncherV2
+from pydantic import computed_field
+from pathlib import Path
+from textwrap import dedent
+from nemo_launcher.core.stages import create_args_list
 
 
 class Stage(BaseModel):

--- a/launcher_scripts/nemo_launcher/core/v2/step_k8s.py
+++ b/launcher_scripts/nemo_launcher/core/v2/step_k8s.py
@@ -1,41 +1,48 @@
-import os
-from textwrap import dedent
-from typing import Any, Callable, Optional
-
-import yaml
-from hera.workflows import Container, Parameter, Resource, Step, Steps, Workflow, script
+from hera.workflows import (
+    Container,
+    Parameter,
+    Step,
+    Steps,
+    Workflow,
+    Resource,
+    script,
+)
 from kubeflow.training import (
+    TrainingClient,
+    KubeflowOrgV1ReplicaSpec,
+    KubeflowOrgV1PyTorchJob,
+    KubeflowOrgV1PyTorchJobSpec,
+    KubeflowOrgV1RunPolicy,
+    KubeflowOrgV1SchedulingPolicy,
     KubeflowOrgV1ElasticPolicy,
     KubeflowOrgV1MPIJob,
     KubeflowOrgV1MPIJobSpec,
-    KubeflowOrgV1PyTorchJob,
-    KubeflowOrgV1PyTorchJobSpec,
-    KubeflowOrgV1ReplicaSpec,
-    KubeflowOrgV1RunPolicy,
-    KubeflowOrgV1SchedulingPolicy,
-    TrainingClient,
 )
 from kubeflow.training.constants import constants
 from kubernetes.client import (
-    ApiClient,
-    V1Capabilities,
-    V1Container,
-    V1ContainerPort,
-    V1EnvVar,
-    V1LocalObjectReference,
+    V1PodTemplateSpec,
     V1ObjectMeta,
     V1PodSpec,
-    V1PodTemplateSpec,
+    V1Container,
+    V1ContainerPort,
     V1ResourceRequirements,
-    V1SecurityContext,
     V1VolumeMount,
-)
-from nemo_launcher.core.v2.config_k8s import (
-    K8sNetworkInterfaces,
-    K8sVolume,
-    adapt_volume_to,
+    V1EnvVar,
+    V1LocalObjectReference,
+    V1SecurityContext,
+    V1Capabilities,
+    ApiClient,
 )
 from pydantic import BaseModel
+import yaml
+from typing import Callable, Any, Optional
+from nemo_launcher.core.v2.config_k8s import (
+    K8sVolume,
+    K8sNetworkInterfaces,
+    adapt_volume_to,
+)
+from textwrap import dedent
+import os
 
 _unset = object()
 

--- a/launcher_scripts/nemo_launcher/core/v2/step_k8s.py
+++ b/launcher_scripts/nemo_launcher/core/v2/step_k8s.py
@@ -30,7 +30,11 @@ from kubernetes.client import (
     V1SecurityContext,
     V1VolumeMount,
 )
-from nemo_launcher.core.v2.config_k8s import K8sNetworkInterfaces, K8sVolume, adapt_volume_to
+from nemo_launcher.core.v2.config_k8s import (
+    K8sNetworkInterfaces,
+    K8sVolume,
+    adapt_volume_to,
+)
 from pydantic import BaseModel
 
 _unset = object()
@@ -78,7 +82,11 @@ def prune_tree(tree: dict, is_prunable: Callable[[Any], bool] = None):
 def to_env_list(env: dict[str, Any]) -> list[V1EnvVar]:
     if not env:
         return []
-    return [V1EnvVar(name=name, value=str(value)) for name, value in env.items() if value is not None]
+    return [
+        V1EnvVar(name=name, value=str(value))
+        for name, value in env.items()
+        if value is not None
+    ]
 
 
 def create_pytorchjob_resource(
@@ -116,7 +124,9 @@ def create_pytorchjob_resource(
     if ports:
         ports = [V1ContainerPort(container_port=p) for p in ports]
     if capabilities:
-        security_context = V1SecurityContext(capabilities=V1Capabilities(add=capabilities))
+        security_context = V1SecurityContext(
+            capabilities=V1Capabilities(add=capabilities)
+        )
     else:
         security_context = None
 
@@ -153,7 +163,9 @@ def create_pytorchjob_resource(
         kind=constants.PYTORCHJOB_KIND,
         metadata=V1ObjectMeta(generate_name=generate_name, namespace=namespace),
         spec=KubeflowOrgV1PyTorchJobSpec(
-            run_policy=KubeflowOrgV1RunPolicy(clean_pod_policy="None", backoff_limit=BACKOFF_LIMIT),
+            run_policy=KubeflowOrgV1RunPolicy(
+                clean_pod_policy="None", backoff_limit=BACKOFF_LIMIT
+            ),
             elastic_policy=KubeflowOrgV1ElasticPolicy(
                 rdzv_backend="c10d",
                 min_replicas=n_workers,
@@ -183,8 +195,13 @@ def create_pytorchjob_resource(
         # at the moment the dependency_name is limited to a single resource
         inputs=resource_inputs,
         outputs=[
-            Parameter(name="metadata_name", value_from={"jsonPath": "{.metadata.name}"}),
-            Parameter(name="metadata_namespace", value_from={"jsonPath": "{.metadata.namespace}"},),
+            Parameter(
+                name="metadata_name", value_from={"jsonPath": "{.metadata.name}"}
+            ),
+            Parameter(
+                name="metadata_namespace",
+                value_from={"jsonPath": "{.metadata.namespace}"},
+            ),
         ],
     )
 
@@ -218,7 +235,9 @@ def create_mpijob_resource(
     else:
         vols, vol_mounts = None, None
     if capabilities:
-        security_context = V1SecurityContext(capabilities=V1Capabilities(add=capabilities))
+        security_context = V1SecurityContext(
+            capabilities=V1Capabilities(add=capabilities)
+        )
     else:
         security_context = None
 
@@ -269,7 +288,9 @@ def create_mpijob_resource(
         metadata=V1ObjectMeta(generate_name=generate_name, namespace=namespace),
         spec=KubeflowOrgV1MPIJobSpec(
             # Clean running pods since the workers will hang around even after the launcher finishes
-            run_policy=KubeflowOrgV1RunPolicy(clean_pod_policy="Running", backoff_limit=BACKOFF_LIMIT),
+            run_policy=KubeflowOrgV1RunPolicy(
+                clean_pod_policy="Running", backoff_limit=BACKOFF_LIMIT
+            ),
             mpi_replica_specs={"Launcher": launcher, "Worker": worker,},
         ),
     )
@@ -292,8 +313,13 @@ def create_mpijob_resource(
         # at the moment the dependency_name is limited to a single resource
         inputs=resource_inputs,
         outputs=[
-            Parameter(name="metadata_name", value_from={"jsonPath": "{.metadata.name}"}),
-            Parameter(name="metadata_namespace", value_from={"jsonPath": "{.metadata.namespace}"},),
+            Parameter(
+                name="metadata_name", value_from={"jsonPath": "{.metadata.name}"}
+            ),
+            Parameter(
+                name="metadata_namespace",
+                value_from={"jsonPath": "{.metadata.namespace}"},
+            ),
         ],
     )
 
@@ -307,4 +333,9 @@ def delete_pytorchjob(name: str = "delete-pytorchjob"):
           name: {{{{inputs.parameters.metadata_name}}}}
         """
     )
-    return Resource(name=name, action="delete", inputs=[Parameter(name="metadata_name")], manifest=manifest,)
+    return Resource(
+        name=name,
+        action="delete",
+        inputs=[Parameter(name="metadata_name")],
+        manifest=manifest,
+    )

--- a/launcher_scripts/nemo_launcher/utils/file_utils.py
+++ b/launcher_scripts/nemo_launcher/utils/file_utils.py
@@ -14,13 +14,14 @@
 
 import os
 from shutil import which
+from typing import Optional
 
 import requests
 import tqdm
 import zstandard as zstd
 
 
-def download_single_file(url: str, save_dir: str, file_name: str | None = None) -> str:
+def download_single_file(url: str, save_dir: str, file_name: Optional[str] = None) -> str:
     os.makedirs(save_dir, exist_ok=True)
     if file_name is None:
         file_name = os.path.basename(url)
@@ -30,13 +31,9 @@ def download_single_file(url: str, save_dir: str, file_name: str | None = None) 
         print(f"File {save_path} already exists, skipping download.")
         return save_path
 
-    with requests.get(url, stream=True) as read_file, open(
-        save_path, "wb"
-    ) as write_file:
+    with requests.get(url, stream=True) as read_file, open(save_path, "wb") as write_file:
         total_length = int(read_file.headers.get("content-length"))
-        with tqdm.tqdm(
-            total=total_length, unit="B", unit_scale=True, desc=file_name,
-        ) as pbar:
+        with tqdm.tqdm(total=total_length, unit="B", unit_scale=True, desc=file_name,) as pbar:
             update_len = 0
             for chunk in read_file.iter_content(chunk_size=8192):
                 if chunk:
@@ -56,18 +53,14 @@ def extract_single_zst_file(input_path, save_dir, file_name, rm_input=False):
         return save_path
 
     total_length = os.stat(input_path).st_size
-    with tqdm.tqdm(
-        total=total_length, unit="B", unit_scale=True, desc=file_name,
-    ) as pbar:
+    with tqdm.tqdm(total=total_length, unit="B", unit_scale=True, desc=file_name,) as pbar:
         dctx = zstd.ZstdDecompressor()
         read_size = 131075
         write_size = int(read_size * 4)
         save_path = os.path.join(save_dir, file_name)
         update_len = 0
         with open(input_path, "rb") as in_f, open(save_path, "wb") as out_f:
-            for chunk in dctx.read_to_iter(
-                in_f, read_size=read_size, write_size=write_size
-            ):
+            for chunk in dctx.read_to_iter(in_f, read_size=read_size, write_size=write_size):
                 out_f.write(chunk)
                 update_len += read_size
                 if update_len >= 3000000:

--- a/launcher_scripts/nemo_launcher/utils/file_utils.py
+++ b/launcher_scripts/nemo_launcher/utils/file_utils.py
@@ -21,7 +21,9 @@ import tqdm
 import zstandard as zstd
 
 
-def download_single_file(url: str, save_dir: str, file_name: Optional[str] = None) -> str:
+def download_single_file(
+    url: str, save_dir: str, file_name: Optional[str] = None
+) -> str:
     os.makedirs(save_dir, exist_ok=True)
     if file_name is None:
         file_name = os.path.basename(url)
@@ -31,9 +33,13 @@ def download_single_file(url: str, save_dir: str, file_name: Optional[str] = Non
         print(f"File {save_path} already exists, skipping download.")
         return save_path
 
-    with requests.get(url, stream=True) as read_file, open(save_path, "wb") as write_file:
+    with requests.get(url, stream=True) as read_file, open(
+        save_path, "wb"
+    ) as write_file:
         total_length = int(read_file.headers.get("content-length"))
-        with tqdm.tqdm(total=total_length, unit="B", unit_scale=True, desc=file_name,) as pbar:
+        with tqdm.tqdm(
+            total=total_length, unit="B", unit_scale=True, desc=file_name,
+        ) as pbar:
             update_len = 0
             for chunk in read_file.iter_content(chunk_size=8192):
                 if chunk:
@@ -53,14 +59,18 @@ def extract_single_zst_file(input_path, save_dir, file_name, rm_input=False):
         return save_path
 
     total_length = os.stat(input_path).st_size
-    with tqdm.tqdm(total=total_length, unit="B", unit_scale=True, desc=file_name,) as pbar:
+    with tqdm.tqdm(
+        total=total_length, unit="B", unit_scale=True, desc=file_name,
+    ) as pbar:
         dctx = zstd.ZstdDecompressor()
         read_size = 131075
         write_size = int(read_size * 4)
         save_path = os.path.join(save_dir, file_name)
         update_len = 0
         with open(input_path, "rb") as in_f, open(save_path, "wb") as out_f:
-            for chunk in dctx.read_to_iter(in_f, read_size=read_size, write_size=write_size):
+            for chunk in dctx.read_to_iter(
+                in_f, read_size=read_size, write_size=write_size
+            ):
                 out_f.write(chunk)
                 update_len += read_size
                 if update_len >= 3000000:


### PR DESCRIPTION
Using `|` (e.g. `str | None`) is only supported in Python 3.10. To support machines/clusters with Python 3.9 or older, this PR converts those typehints to `typing.Union` or `typing.Optional`.