### PR TITLE
Small updates for llama2 and nemotron base configs

### DIFF
--- a/launcher_scripts/conf/peft/llama/sft.yaml
+++ b/launcher_scripts/conf/peft/llama/sft.yaml
@@ -81,6 +81,7 @@ model:
 
   megatron_amp_O2: True
   mcore_gpt: True
+  transformer_engine: True
 
   get_attention_mask_from_fusion: True
   apply_rope_fusion: True

--- a/launcher_scripts/conf/peft/nemotron/sft.yaml
+++ b/launcher_scripts/conf/peft/nemotron/sft.yaml
@@ -81,6 +81,7 @@ model:
 
   megatron_amp_O2: True
   mcore_gpt: True
+  transformer_engine: True
 
   get_attention_mask_from_fusion: True
   apply_rope_fusion: True

--- a/launcher_scripts/conf/peft/nemotron/sft.yaml
+++ b/launcher_scripts/conf/peft/nemotron/sft.yaml
@@ -113,7 +113,7 @@ model:
   # 'block' checkpoints the specified number of layers per pipeline stage at the specified granularity
   activations_checkpoint_num_layers: null # not used with 'selective'
   activations_checkpoint_layers_per_pipeline: null
-  answer_only_loss: False
+  answer_only_loss: True
   gradient_as_bucket_view: True
 
   hidden_dropout: 0.0


### PR DESCRIPTION
- Set transformer_engine=true explicitly in both configs, due to the recent change in function of this flag (which could cause `AssertionError: (RMSNorm) is not supported in FusedLayerNorm when instantiating FusedLayerNorm` if it was unset)
- Set answer_only_loss=true by default for nemotron, which improves convergence