### PR TITLE
use env TRANSFORMERS_CACHE if available

### DIFF
--- a/launcher_scripts/conf/config.yaml
+++ b/launcher_scripts/conf/config.yaml
@@ -62,7 +62,7 @@ env_vars:
   NCCL_IB_TIMEOUT: null # InfiniBand Verbs Timeout. Set to 22 for Azure
   NCCL_DEBUG: null # Logging level for NCCL. Set to "INFO" for debug information
   NCCL_PROTO: null # Protocol NCCL will use. Set to "simple" for AWS
-  TRANSFORMERS_OFFLINE: 1
+  TRANSFORMERS_OFFLINE: 0
   TORCH_NCCL_AVOID_RECORD_STREAMS: 1
   NCCL_NVLS_ENABLE: 0
   NVTE_DP_AMAX_REDUCE_INTERVAL: 0 # Diable FP8 AMAX reduction in the data-parallel domain

--- a/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/preprocess.py
+++ b/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/preprocess.py
@@ -37,7 +37,7 @@ def main(cfg):
     assert vocab_dir is not None, "vocab_save_dir must be a valid path."
     if "gpt" in tokenizer_type.lower():
         vocab_path = os.path.join(launcher_scripts_path, vocab_dir, "vocab.json")
-    elif tokenizer_library.lower() == 'huggingface':
+    elif tokenizer_library.lower() == "huggingface":
         vocab_path = None
     else:
         vocab_path = os.path.join(launcher_scripts_path, vocab_dir, "vocab.txt")

--- a/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/preprocess.py
+++ b/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/preprocess.py
@@ -59,10 +59,11 @@ def main(cfg):
     code_path = (
         "/opt/NeMo/scripts/nlp_language_modeling/preprocess_data_for_megatron.py"
     )
+    hf_cache = os.environ.get("TRANSFORMERS_CACHE", "/temp_root/.cache/")
     runcmd = (
         f"cd {megatron_dir}; "
         f'export PYTHONPATH="/opt/NeMo/.:$PYTHONPATH"; '
-        f'export TRANSFORMERS_CACHE="/temp_root/.cache/"; '
+        f'export TRANSFORMERS_CACHE="{hf_cache}"; '
         f"python3 {code_path} "
     )
 

--- a/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/preprocess.py
+++ b/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/preprocess.py
@@ -37,6 +37,8 @@ def main(cfg):
     assert vocab_dir is not None, "vocab_save_dir must be a valid path."
     if "gpt" in tokenizer_type.lower():
         vocab_path = os.path.join(launcher_scripts_path, vocab_dir, "vocab.json")
+    elif tokenizer_library.lower() == 'huggingface':
+        vocab_path = None
     else:
         vocab_path = os.path.join(launcher_scripts_path, vocab_dir, "vocab.txt")
 
@@ -90,14 +92,14 @@ def main(cfg):
         flags = (
             f"--input {extracted_path} "
             f"--output-prefix {output_prefix} "
-            f"--vocab {vocab_path} "
             f"--dataset-impl mmap "
             f"--tokenizer-type {tokenizer_type} "
             f"--tokenizer-library {tokenizer_library} "
             f"--tokenizer-model {tokenizer_model} "
             f"--workers $SLURM_CPUS_ON_NODE "
         )
-
+        if vocab_path is not None:
+            flags += f"--vocab {vocab_path} "
         if model_type == "bert":
             # Used for bert binary head (Next sentence predition)
             flags += "--split-sentences "
@@ -150,15 +152,14 @@ def main(cfg):
             flags = (
                 f"--input {extracted_path} "
                 f"--output-prefix {output_prefix} "
-                f"--vocab {vocab_path} "
                 f"--dataset-impl mmap "
-                f"--tokenizer-library megatron "
                 f"--tokenizer-type {tokenizer_type} "
                 f"--tokenizer-library {tokenizer_library} "
                 f"--tokenizer-model {tokenizer_model} "
                 f"--workers {ncpus} "
             )
-
+            if vocab_path is not None:
+                flags += f"--vocab {vocab_path} "
             if model_type == "bert":
                 # Used for bert binary head (Next sentence predition)
                 flags += "--split-sentences "

--- a/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/preprocess.py
+++ b/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/preprocess.py
@@ -92,7 +92,6 @@ def main(cfg):
             f"--output-prefix {output_prefix} "
             f"--vocab {vocab_path} "
             f"--dataset-impl mmap "
-            f"--tokenizer-library megatron "
             f"--tokenizer-type {tokenizer_type} "
             f"--tokenizer-library {tokenizer_library} "
             f"--tokenizer-model {tokenizer_model} "

--- a/launcher_scripts/tests/unit_tests/config_tests/test_main_config.py
+++ b/launcher_scripts/tests/unit_tests/config_tests/test_main_config.py
@@ -68,7 +68,7 @@ class TestConfig:
           NCCL_IB_TIMEOUT: null # InfiniBand Verbs Timeout. Set to 22 for Azure
           NCCL_DEBUG: null # Logging level for NCCL. Set to "INFO" for debug information
           NCCL_PROTO: null # Protocol NCCL will use. Set to "simple" for AWS
-          TRANSFORMERS_OFFLINE: 1
+          TRANSFORMERS_OFFLINE: 0
           TORCH_NCCL_AVOID_RECORD_STREAMS: 1
           NCCL_NVLS_ENABLE: 0
           NVTE_DP_AMAX_REDUCE_INTERVAL: 0 # Diable FP8 AMAX reduction in the data-parallel domain


### PR DESCRIPTION
Prefer the user specified TRANSFORMERS_CACHE if available, otherwise fallback to default.

the issues were two
1. it was hardcoding the transformers_cache env var and so if you specify it in the outer script it would not pass it down.
2. the tokenizer-library was always being megatron & not changing if the use used HF