### PR TITLE
Add default gc_interval=100 for llama and nemotron fine-tuning

### DIFF
--- a/launcher_scripts/conf/peft/llama/sft.yaml
+++ b/launcher_scripts/conf/peft/llama/sft.yaml
@@ -120,6 +120,8 @@ model:
   attention_dropout: 0.0
   ffn_dropout: 0.0
 
+  gc_interval: 100
+
   peft:
     peft_scheme: null  # null (SFT, no PEFT), ptuning, lora
     restore_from_path: null

--- a/launcher_scripts/conf/peft/nemotron/sft.yaml
+++ b/launcher_scripts/conf/peft/nemotron/sft.yaml
@@ -120,6 +120,8 @@ model:
   attention_dropout: 0.0
   ffn_dropout: 0.0
 
+  gc_interval: 100
+
   peft:
     peft_scheme: null  # null (SFT, no PEFT), ptuning, lora
     restore_from_path: null


### PR DESCRIPTION
Added default setting model.gc_interval=100 for llama and nemotron fine-tuning (to reduce time spikes during training).