### PR TITLE
Pass LD_LIBRARY_PATH EV to mpirun command

### DIFF
--- a/launcher_scripts/nemo_launcher/core/v2/stages.py
+++ b/launcher_scripts/nemo_launcher/core/v2/stages.py
@@ -442,7 +442,7 @@ class PileDataPreparation(Stage):
             ]
 
             mpirun_template = (
-                lambda script_name: f'mpirun --allow-run-as-root -np { self.n_total_processes } -npernode { self.n_proc_per_worker } -bind-to none -map-by slot --oversubscribe -x PYTHONPATH -mca pml ob1 -mca btl ^openib python3 {script_name} {" ".join(hydra_config_as_args)}'
+                lambda script_name: f'mpirun --allow-run-as-root -np { self.n_total_processes } -npernode { self.n_proc_per_worker } -bind-to none -map-by slot --oversubscribe -x PYTHONPATH -x LD_LIBRARY_PATH -mca pml ob1 -mca btl ^openib python3 {script_name} {" ".join(hydra_config_as_args)}'
             )
             commands = []
             for script_path in (


### PR DESCRIPTION
Some k8s platforms can overwrite LD_LIBRARY_PATH variables which can prevent the container from recognizing CUDA drivers in some scenarios. Adding the LD_LIBRARY_PATH EV to mpirun commands ensures that the spawned processes with mpirun will be able to see the necessary libraries. The LD_LIBRARY_PATH EV can also be set while launching jobs.