### PR TITLE
Allow imagePullSecrets to be optional

### DIFF
--- a/launcher_scripts/conf/cluster/k8s_v2.yaml
+++ b/launcher_scripts/conf/cluster/k8s_v2.yaml
@@ -21,5 +21,4 @@ ib_interfaces:
     # nvidia.com/hostdev: 8
 
 dns_policy: null  # Specify a dnsPolicy to use in all pods, if necessary
-pull_secret: ngc-registry  # Kubernetes secret for the container registry to pull private containers.
-capabilities: []
+pull_secret: ngc-registry  # Kubernetes secret for the container registry to pull private containers. Set to "null" if the imagePullSecret is managed by the scheduler or otherwise not needed.

--- a/launcher_scripts/nemo_launcher/core/v2/config_k8s.py
+++ b/launcher_scripts/nemo_launcher/core/v2/config_k8s.py
@@ -174,8 +174,8 @@ class K8sClusterConfig(BaseModel):
 
     ib_interfaces: Optional[K8sNetworkInterfaces] = None
     # dns_policy: str | None = None # Specify a dnsPolicy to use in all pods, if necessary
-    pull_secret: str = "ngc-registry"  # Kubernetes secret for the container registry to pull private containers.
     shm_size: str = "512Gi"  # Amount of system memory to allocate in Pods. Should end in "Gi" for gigabytes.
+    pull_secret: Optional[str] = "ngc-registry"  # Kubernetes secret for the container registry to pull private containers. Set to "null" if the imagePullSecret is managed by the scheduler or otherwise not needed.
     capabilities: Optional[list[str]] = [
         "IPC_LOCK"
     ]  # capabilities to add to all containers (useful for debugging), ex. ["IPC_LOCK", "SYS_PTRACE"]


### PR DESCRIPTION
Certain cluster schedulers, such as Run:ai, handle imagePullSecrets independently of what's listed in the manifest file. Additonally, it's possible that users could push a custom NeMo image to another container registry that doesn't require authentication. As such, the ability to omit the imagePullSecret from the config should be supported to allow users to run jobs on kubernetes without it.