### PR TITLE
Allow custom API versions for k8s operators

### DIFF
--- a/launcher_scripts/conf/cluster/k8s_v2.yaml
+++ b/launcher_scripts/conf/cluster/k8s_v2.yaml
@@ -23,3 +23,5 @@ ib_interfaces:
 dns_policy: null  # Specify a dnsPolicy to use in all pods, if necessary
 pull_secret: ngc-registry  # Kubernetes secret for the container registry to pull private containers.
 capabilities: []
+custom_mpijob_api_version: null  # Optionally specify a custom k8s API version for MPIJobs. Default is "kubeflow.org/v1". This occurs when a cluster has different API versions installed.
+custom_pytorchjob_api_version: null  # Optionally specify a custom k8s API version for PyTorchJobs. Default is "kubeflow.org/v1". This occurs when a cluster has different API versions installed.

--- a/launcher_scripts/nemo_launcher/core/v2/config_k8s.py
+++ b/launcher_scripts/nemo_launcher/core/v2/config_k8s.py
@@ -179,6 +179,8 @@ class K8sClusterConfig(BaseModel):
     capabilities: Optional[list[str]] = [
         "IPC_LOCK"
     ]  # capabilities to add to all containers (useful for debugging), ex. ["IPC_LOCK", "SYS_PTRACE"]
+    custom_mpijob_api_version: Optional[str] = None  # Optionally specify a custom k8s API version for MPIJobs. Default is "kubeflow.org/v1". This occurs when a cluster has different API versions installed.
+    custom_pytorchjob_api_version: Optional[str] = None  # Optionally specify a custom k8s API version for PyTorchJobs. Default is "kubeflow.org/v1". This occurs when a cluster has different API versions installed.
 
     def check_path_in_volumes(self, path: str):
         # This is a helper method to help make sure users configure their k8s paths correctly.

--- a/launcher_scripts/nemo_launcher/core/v2/stages.py
+++ b/launcher_scripts/nemo_launcher/core/v2/stages.py
@@ -166,6 +166,7 @@ class Training(Stage):
                 n_workers=self.n_workers,
                 gpus_per_worker=self.gpus_per_worker,
                 namespace=self.cluster_cfg.namespace,
+                pytorch_version=self.cluster_cfg.custom_pytorchjob_api_version,
                 env=self.env,
                 command=[
                     "bash",
@@ -285,6 +286,7 @@ class PEFT(Stage):
                 n_workers=self.n_workers,
                 gpus_per_worker=self.gpus_per_worker,
                 namespace=self.cluster_cfg.namespace,
+                pytorch_version=self.cluster_cfg.custom_pytorchjob_api_version,
                 env=self.env,
                 command=[
                     "bash",
@@ -466,6 +468,7 @@ class PileDataPreparation(Stage):
                 command=["bash", "-euxc", commands_str],
                 volumes=self.cluster_cfg.volumes,
                 network_interfaces=self.cluster_cfg.ib_interfaces,
+                mpijob_version=self.cluster_cfg.custom_mpijob_api_version,
                 capabilities=self.cluster_cfg.capabilities,
             )
             with Steps(name="data-steps") as s:
@@ -571,6 +574,7 @@ class RLHFPPO(Stage):
                 n_workers=self.n_critic_workers,
                 gpus_per_worker=self.n_critic_gpus_per_worker,
                 namespace=self.cluster_cfg.namespace,
+                pytorch_version=self.cluster_cfg.custom_pytorchjob_api_version,
                 env=self.env,
                 command=[
                     "bash",
@@ -599,6 +603,7 @@ torchrun {self.critic_script} --config-path=/config --config-name=config.yaml \
                 n_workers=self.n_actor_workers,
                 gpus_per_worker=self.n_actor_gpus_per_worker,
                 namespace=self.cluster_cfg.namespace,
+                pytorch_version=self.cluster_cfg.custom_pytorchjob_api_version,
                 env=self.env,
                 command=[
                     "bash",
@@ -707,6 +712,7 @@ class RLHFRewardModel(Stage):
                 n_workers=self.n_workers,
                 gpus_per_worker=self.gpus_per_worker,
                 namespace=self.cluster_cfg.namespace,
+                pytorch_version=self.cluster_cfg.custom_pytorchjob_api_version,
                 env=self.env,
                 command=[
                     "bash",

--- a/launcher_scripts/nemo_launcher/core/v2/step_k8s.py
+++ b/launcher_scripts/nemo_launcher/core/v2/step_k8s.py
@@ -108,6 +108,7 @@ def create_pytorchjob_resource(
     image_pull_secret: Optional[str] = None,
     volumes: Optional[dict[str, K8sVolume]] = None,
     network_interfaces: Optional[K8sNetworkInterfaces] = None,
+    pytorch_version: Optional[str] = None,
     ports: Optional[list[int]] = None,
     success_condition: Optional[str] = _unset,
     resource_inputs: Optional[list[Parameter]] = None,
@@ -166,7 +167,7 @@ def create_pytorchjob_resource(
         ),
     )
     pytorch_job = KubeflowOrgV1PyTorchJob(
-        api_version=f"{constants.API_VERSION}",
+        api_version=pytorch_version if pytorch_version else f"{constants.API_VERSION}",
         kind=constants.PYTORCHJOB_KIND,
         metadata=V1ObjectMeta(generate_name=generate_name, namespace=namespace),
         spec=KubeflowOrgV1PyTorchJobSpec(
@@ -224,6 +225,7 @@ def create_mpijob_resource(
     image_pull_secret: Optional[str] = None,
     volumes: Optional[dict[str, K8sVolume]] = None,
     network_interfaces: Optional[K8sNetworkInterfaces] = None,
+    mpijob_version: Optional[str] = None,
     success_condition: Optional[str] = _unset,
     resource_inputs: Optional[list[Parameter]] = None,
     capabilities: Optional[list[str]] = None,
@@ -290,7 +292,7 @@ def create_mpijob_resource(
     launcher = replica_template(n_replicas=1, container=launch_container,)
     worker = replica_template(n_replicas=n_workers, container=worker_container,)
     mpijob = KubeflowOrgV1MPIJob(
-        api_version=f"{constants.API_VERSION}",
+        api_version=mpijob_version if mpijob_version else f"{constants.API_VERSION}",
         kind=constants.MPIJOB_KIND,
         metadata=V1ObjectMeta(generate_name=generate_name, namespace=namespace),
         spec=KubeflowOrgV1MPIJobSpec(


### PR DESCRIPTION
Some clusters use different API versions for PyTorchJobs and MPIJobs than the default versions identified by the KubeFlow Training package. Users can override the default version with a config change as needed.