### PR TITLE
Remove dup line in `llama3_1_8b.yaml`

### DIFF
--- a/launcher_scripts/conf/training/llama/llama3_1_8b.yaml
+++ b/launcher_scripts/conf/training/llama/llama3_1_8b.yaml
@@ -124,7 +124,6 @@ model:
   num_micro_batches_with_partial_activation_checkpoints: null
   activations_checkpoint_layers_per_pipeline: null
   sequence_parallel: false
-  sequence_parallel: false
   deterministic_mode: false
 
   ## Transformer Engine


### PR DESCRIPTION
This line is a duplicate of the previous line. If it is not removed, it will cause an omegaconf error with the message 'found duplicate key sequence_parallel'. Alternatively, could you explain why it is necessary to have independent 'llama3_1_xb' configurations when the 'llama3_xb' configuration files already exist?