### PR TITLE
Enabled attention masking for Llama 3 according to the model card

### DIFF
--- a/launcher_scripts/conf/training/llama/llama3_1_405b.yaml
+++ b/launcher_scripts/conf/training/llama/llama3_1_405b.yaml
@@ -173,8 +173,8 @@ model:
     skip_warmup: true
     num_workers: 2
     dataloader_type: single
-    reset_position_ids: false
-    reset_attention_mask: false
+    reset_position_ids: true
+    reset_attention_mask: true
     eod_mask_loss: false
     index_mapping_dir: null
     data_prefix:

--- a/launcher_scripts/conf/training/llama/llama3_1_70b.yaml
+++ b/launcher_scripts/conf/training/llama/llama3_1_70b.yaml
@@ -173,8 +173,8 @@ model:
     skip_warmup: true
     num_workers: 2
     dataloader_type: single
-    reset_position_ids: false
-    reset_attention_mask: false
+    reset_position_ids: true
+    reset_attention_mask: true
     eod_mask_loss: false
     index_mapping_dir: null
     data_prefix:

--- a/launcher_scripts/conf/training/llama/llama3_1_8b.yaml
+++ b/launcher_scripts/conf/training/llama/llama3_1_8b.yaml
@@ -124,7 +124,6 @@ model:
   num_micro_batches_with_partial_activation_checkpoints: null
   activations_checkpoint_layers_per_pipeline: null
   sequence_parallel: false
-  sequence_parallel: false
   deterministic_mode: false
 
   ## Transformer Engine
@@ -170,8 +169,8 @@ model:
     skip_warmup: true
     num_workers: 2
     dataloader_type: single
-    reset_position_ids: false
-    reset_attention_mask: false
+    reset_position_ids: true
+    reset_attention_mask: true
     eod_mask_loss: false
     index_mapping_dir: null
     data_prefix:

--- a/launcher_scripts/conf/training/llama/llama3_70b.yaml
+++ b/launcher_scripts/conf/training/llama/llama3_70b.yaml
@@ -172,8 +172,8 @@ model:
     skip_warmup: true
     num_workers: 2
     dataloader_type: single
-    reset_position_ids: false
-    reset_attention_mask: false
+    reset_position_ids: true
+    reset_attention_mask: true
     eod_mask_loss: false
     index_mapping_dir: null
     data_prefix:

--- a/launcher_scripts/conf/training/llama/llama3_8b.yaml
+++ b/launcher_scripts/conf/training/llama/llama3_8b.yaml
@@ -168,8 +168,8 @@ model:
     skip_warmup: true
     num_workers: 2
     dataloader_type: single
-    reset_position_ids: false
-    reset_attention_mask: false
+    reset_position_ids: true
+    reset_attention_mask: true
     eod_mask_loss: false
     index_mapping_dir: null
     data_prefix:


### PR DESCRIPTION
According to [Llama 3 blog post](https://ai.meta.com/blog/meta-llama-3/), "We trained the models on sequences of 8,192 tokens, using a mask to ensure self-attention does not cross document boundaries.". The current Llama 3 configs don't use attention masking for self-attention.