### PR TITLE
Adding llama3 rotary_base

### DIFF
--- a/launcher_scripts/conf/training/llama/llama3_1_405b.yaml
+++ b/launcher_scripts/conf/training/llama/llama3_1_405b.yaml
@@ -89,6 +89,7 @@ model:
   openai_gelu: false
   normalize_attention_scores: true
   position_embedding_type: rope
+  rotary_base: 500000.0
   rotary_percentage: 1.0
   apply_rope_fusion: true
   attention_type: multihead

--- a/launcher_scripts/conf/training/llama/llama3_1_70b.yaml
+++ b/launcher_scripts/conf/training/llama/llama3_1_70b.yaml
@@ -90,6 +90,7 @@ model:
   normalize_attention_scores: true
   position_embedding_type: rope
   rotary_percentage: 1.0
+  rotary_base: 500000.0
   apply_rope_fusion: true
   attention_type: multihead
   share_embeddings_and_output_weights: false

--- a/launcher_scripts/conf/training/llama/llama3_1_8b.yaml
+++ b/launcher_scripts/conf/training/llama/llama3_1_8b.yaml
@@ -90,6 +90,7 @@ model:
   normalize_attention_scores: true
   position_embedding_type: rope
   rotary_percentage: 1.0
+  rotary_base: 500000.0
   apply_rope_fusion: true
   cross_entropy_loss_fusion: true
   attention_type: multihead

--- a/launcher_scripts/conf/training/llama/llama3_70b.yaml
+++ b/launcher_scripts/conf/training/llama/llama3_70b.yaml
@@ -89,6 +89,7 @@ model:
   openai_gelu: false
   normalize_attention_scores: true
   position_embedding_type: rope
+  rotary_base: 500000.0
   rotary_percentage: 1.0
   apply_rope_fusion: true
   attention_type: multihead

--- a/launcher_scripts/conf/training/llama/llama3_8b.yaml
+++ b/launcher_scripts/conf/training/llama/llama3_8b.yaml
@@ -89,6 +89,7 @@ model:
   openai_gelu: false
   normalize_attention_scores: true
   position_embedding_type: rope
+  rotary_base: 500000.0
   rotary_percentage: 1.0
   apply_rope_fusion: true
   cross_entropy_loss_fusion: true


### PR DESCRIPTION
The default value for `rotary_base` is **10000** [[1]](https://github.com/NVIDIA/Megatron-LM/blob/392bc05c72f4d6b37d82043fc817ea4a9e44d1a5/megatron/core/models/gpt/gpt_model.py#L71), [[2]](https://github.com/NVIDIA/NeMo/blob/5c5b023da44a19ab94a954f2e00cad16e3e807ca/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py#L497) while Llama3 models use **500000** [[3](https://arxiv.org/pdf/2407.21783), Table 3 "Positional Embeddings"], [[4]](https://huggingface.co/meta-llama/Llama-3.1-8B/blob/d04e592bb4f6aa9cfee91e2e20afa771667e1d4b/config.json#L28).

Other models such Qwen2 also use other `rotary_base` values which are properly configured in the launcher [[5]](https://github.com/NVIDIA/NeMo-Framework-Launcher/blob/597f83a4f3b04a7a60fdd7e1a51b5bfeb8d81ae8/auto_configurator/base_configs/qwen2_72b.yaml#L66)