### PR TITLE
Add GPU metrics support for nsight profiling

### DIFF
--- a/launcher_scripts/nemo_launcher/core/stages.py
+++ b/launcher_scripts/nemo_launcher/core/stages.py
@@ -292,7 +292,7 @@ class NemoMegatronStage:
             )
             if nsys_cfg.get("gpu_metrics", False):
                 slurm_local_rank = "\${SLURM_LOCALID}"
-                nsys_prefix += (f"--gpu-metrics-device={slurm_local_rank} ")
+                nsys_prefix += f"--gpu-metrics-device={slurm_local_rank} "
         return nsys_prefix
 
     def _make_container_mounts_string(self) -> str:

--- a/launcher_scripts/nemo_launcher/core/stages.py
+++ b/launcher_scripts/nemo_launcher/core/stages.py
@@ -290,6 +290,9 @@ class NemoMegatronStage:
                 f"--capture-range-end=stop "
                 f"--cuda-graph-trace=node "
             )
+            if nsys_cfg.get("gpu_metrics", False):
+                slurm_local_rank = "\${SLURM_LOCALID}"
+                nsys_prefix += (f"--gpu-metrics-device={slurm_local_rank} ")
         return nsys_prefix
 
     def _make_container_mounts_string(self) -> str:


### PR DESCRIPTION
Profiling with Nsight systems is enabled but additional option of GPU metrics is optional in some systems that can add valuable trace info. 
The addition enables that ability for the profiled rank attached GPU in privileged systems and is disabled by default.